### PR TITLE
Disable trading page pop-ups

### DIFF
--- a/app/tokens/[id]/page.tsx
+++ b/app/tokens/[id]/page.tsx
@@ -5,7 +5,7 @@ import { Header } from '@/components/Header';
 import { BottomNav } from '@/components/BottomNav';
 import { useBondingCurves } from '@/lib/hooks/useBondingCurves';
 import { TradingModal } from '@/components/modals/TradingModal';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 export default function TokenPage() {
   const params = useParams();
@@ -16,12 +16,12 @@ export default function TokenPage() {
   // Find the token by ID
   const token = curves?.find(c => c.id === tokenId);
 
-  // Auto-open trading modal when token is loaded
-  useEffect(() => {
-    if (token && !showTrading) {
-      setShowTrading(true);
-    }
-  }, [token]);
+  // Auto-open trading modal disabled - user can manually open it
+  // useEffect(() => {
+  //   if (token && !showTrading) {
+  //     setShowTrading(true);
+  //   }
+  // }, [token]);
 
   if (isLoading) {
     return (
@@ -64,17 +64,52 @@ export default function TokenPage() {
     <div className="min-h-screen pb-20 md:pb-0">
       <Header />
       <main className="container mx-auto px-4 py-8">
-        {/* Token will be displayed via the trading modal */}
+        {/* Token Info Card with Trade Button */}
+        {token && (
+          <div className="max-w-2xl mx-auto">
+            <div className="bg-white/5 border border-white/10 rounded-lg p-6 mb-4">
+              <div className="flex items-center gap-4 mb-6">
+                <div className="w-20 h-20 bg-gradient-to-br from-meme-pink/20 to-sui-blue/20 rounded-lg flex items-center justify-center text-4xl overflow-hidden">
+                  {token.imageUrl ? (
+                    <img src={token.imageUrl} alt={token.ticker} className="w-full h-full object-cover" />
+                  ) : (
+                    '🚀'
+                  )}
+                </div>
+                <div>
+                  <h1 className="text-3xl font-bold">${token.ticker}</h1>
+                  <p className="text-gray-400">{token.name}</p>
+                </div>
+              </div>
+
+              {token.description && (
+                <div className="mb-6">
+                  <h3 className="font-semibold mb-2">About</h3>
+                  <p className="text-gray-300 text-sm">{token.description}</p>
+                </div>
+              )}
+
+              <button
+                onClick={() => setShowTrading(true)}
+                className="w-full py-4 bg-gradient-to-r from-meme-pink to-meme-purple hover:from-meme-pink/80 hover:to-meme-purple/80 rounded-lg font-bold text-lg transition-all hover:scale-105"
+              >
+                🔥 Open Trading
+              </button>
+            </div>
+
+            <a
+              href="/tokens"
+              className="inline-block text-gray-400 hover:text-white transition-colors"
+            >
+              ← Back to all tokens
+            </a>
+          </div>
+        )}
+
         {token && (
           <TradingModal
             isOpen={showTrading}
-            onClose={() => {
-              setShowTrading(false);
-              // Redirect back to tokens list after closing
-              setTimeout(() => {
-                window.location.href = '/tokens';
-              }, 300);
-            }}
+            onClose={() => setShowTrading(false)}
             curve={token}
           />
         )}


### PR DESCRIPTION
Disable automatic trading modal pop-up on token detail page and add a manual 'Open Trading' button for improved user control.

The previous implementation automatically opened the trading modal upon page load, creating an immediate pop-up experience. This change addresses user feedback by providing a more controlled flow, allowing users to view token details before explicitly choosing to open the trading interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd650dd7-8f95-48e5-a96b-dc9e7cb6a501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd650dd7-8f95-48e5-a96b-dc9e7cb6a501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

