### PR TITLE
Check in with user

### DIFF
--- a/app/api/sui-price/route.ts
+++ b/app/api/sui-price/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 30; // Cache for 30 seconds
+
+export async function GET() {
+  try {
+    const response = await fetch(
+      'https://api.coingecko.com/api/v3/simple/price?ids=sui&vs_currencies=usd',
+      {
+        headers: {
+          'Accept': 'application/json',
+        },
+        next: { revalidate: 30 }, // Cache on server side for 30 seconds
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`CoinGecko API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json({
+      price: data.sui.usd,
+      timestamp: Date.now(),
+    });
+  } catch (error) {
+    console.error('Failed to fetch SUI price from CoinGecko:', error);
+    
+    // Return fallback price with error indicator
+    return NextResponse.json(
+      {
+        price: 2.1, // Reasonable fallback
+        timestamp: Date.now(),
+        error: 'Failed to fetch from CoinGecko',
+      },
+      { status: 200 } // Still return 200 so frontend doesn't break
+    );
+  }
+}

--- a/lib/hooks/useSuiPrice.ts
+++ b/lib/hooks/useSuiPrice.ts
@@ -15,25 +15,23 @@ export function useSuiPrice() {
     queryKey: ['sui-price'],
     queryFn: async (): Promise<number> => {
       try {
-        const response = await fetch(
-          'https://api.coingecko.com/api/v3/simple/price?ids=sui&vs_currencies=usd',
-          {
-            headers: {
-              'Accept': 'application/json',
-            },
-          }
-        );
+        // Use our own API route to avoid CORS and rate limiting issues
+        const response = await fetch('/api/sui-price', {
+          headers: {
+            'Accept': 'application/json',
+          },
+        });
 
         if (!response.ok) {
           throw new Error('Failed to fetch SUI price');
         }
 
-        const data: SuiPriceData = await response.json();
-        return data.sui.usd;
+        const data = await response.json();
+        return data.price;
       } catch (error) {
         console.error('Failed to fetch SUI price:', error);
         // Return fallback price
-        return 1.0;
+        return 2.1;
       }
     },
     refetchInterval: 60000, // Refresh every 60 seconds


### PR DESCRIPTION
Fix CoinGecko API failing to fetch SUI price by proxying requests through a new server-side API route.

The frontend was directly calling CoinGecko, leading to CORS and rate-limiting issues, and silently falling back to a $1.0 price. This PR introduces a `/api/sui-price` route to fetch the price server-side with caching, and updates the `useSuiPrice` hook to use this new route, also updating the fallback price to a more realistic $2.1.

---
<a href="https://cursor.com/background-agent?bcId=bc-f04570a3-4070-4513-9a26-3b9956e72c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f04570a3-4070-4513-9a26-3b9956e72c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

